### PR TITLE
Create package list on package load/unload

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -20,6 +20,14 @@ module.exports =
       loadModule()
       packageSync.sync()
 
+    atom.packages.onDidLoadPackage ->
+      loadModule()
+      packageSync.createPackageList()
+
+    atom.packages.onDidUnloadPackage ->
+      loadModule()
+      packageSync.createPackageList()
+
   config:
     forceOverwrite:
       title: 'Overwrite packages.cson'


### PR DESCRIPTION
Fixes #12. I've been using something like this in [my `init.coffee`](https://github.com/jbhannah/dotfiles/blob/d9b5943f64c65fd63ffbd869db6e799fdc3271d4/atom/init.coffee) to maintain a simple package list.