### PR TITLE
Sync packages on startup

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,32 +1,16 @@
-PackageSync = null
-packageSync = null
-
-# Loads the module on-demand.
-loadModule = ->
-  PackageSync ?= require './package-sync'
-  packageSync ?= new PackageSync()
+PackageSync = require './package-sync'
+packageSync = new PackageSync()
 
 module.exports =
   activate: ->
-    atom.commands.add 'atom-workspace', 'package-sync:create-package-list', ->
-      loadModule()
-      packageSync.createPackageList()
+    packageSync.sync()
 
-    atom.commands.add 'atom-workspace', 'package-sync:open-package-list', ->
-      loadModule()
-      packageSync.openPackageList()
+    atom.commands.add 'atom-workspace', 'package-sync:create-package-list', packageSync.createPackageList
+    atom.commands.add 'atom-workspace', 'package-sync:open-package-list', packageSync.openPackageList
+    atom.commands.add 'atom-workspace', 'package-sync:sync', packageSync.sync
 
-    atom.commands.add 'atom-workspace', 'package-sync:sync', ->
-      loadModule()
-      packageSync.sync()
-
-    atom.packages.onDidLoadPackage ->
-      loadModule()
-      packageSync.createPackageList()
-
-    atom.packages.onDidUnloadPackage ->
-      loadModule()
-      packageSync.createPackageList()
+    atom.packages.onDidLoadPackage packageSync.createPackageList
+    atom.packages.onDidUnloadPackage packageSync.createPackageList
 
   config:
     forceOverwrite:


### PR DESCRIPTION
Fixes #13. Requires removing on-demand module loading, which adds 15ms to startup time.