### PR TITLE
Create package list when packages are installed or removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Where the contents of the array is a list of packages to ensure are installed.
 
 ### Configuration
 
+* `createOnChange` &mdash; Create the package list when packages are installed or removed via the Atom settings
 * `forceOverwrite` &mdash; Forces the `create-package-list` command to overwrite the `packages.cson` if it exists
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Where the contents of the array is a list of packages to ensure are installed.
 
 ### Configuration
 
-* `createOnChange` &mdash; Create the package list when packages are installed or removed via the Atom settings
-* `forceOverwrite` &mdash; Forces the `create-package-list` command to overwrite the `packages.cson` if it exists
+* `createOnChange` &mdash; Create the package list when packages are installed or removed via the Atom settings. You must restart Atom after installing Package Sync for this setting to take effect, and it works best when paired with the `forceOverwrite` setting.
+* `forceOverwrite` &mdash; Forces the `create-package-list` command to overwrite the `packages.cson` if it exists.
 
 ### Commands
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -20,9 +20,25 @@ module.exports =
       loadModule()
       packageSync.sync()
 
+    atom.packages.onDidActivateInitialPackages ->
+      atom.packages.onDidLoadPackage ->
+        if atom.config.get('package-sync.createOnChange')
+          loadModule()
+          packageSync.createPackageList()
+
+      atom.packages.onDidUnloadPackage ->
+        if atom.config.get('package-sync.createOnChange')
+          loadModule()
+          packageSync.createPackageList()
+
   config:
     forceOverwrite:
       title: 'Overwrite packages.cson'
       description: 'Overwrite packages.cson even when it is present.'
+      type: 'boolean'
+      default: false
+    createOnChange:
+      title: 'Create on change'
+      description: 'Create package list when packages are installed or removed.'
       type: 'boolean'
       default: false


### PR DESCRIPTION
Another shot at #18; fixes #12. Registers one callback that toggles a boolean when all packages are activated on startup, and another callback that on package load, if initial package activation has completed and the config value is true, writes to the package list.