### PR TITLE
Uninstall packages not listed in packages.cson

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Where the contents of the array is a list of packages to ensure are installed.
 
 * `createOnChange` &mdash; Create the package list when packages are installed or removed via the Atom settings. You must restart Atom after installing Package Sync for this setting to take effect, and it works best when paired with the `forceOverwrite` setting.
 * `forceOverwrite` &mdash; Forces the `create-package-list` command to overwrite the `packages.cson` if it exists.
+* `uninstall` &mdash; Uninstall packages missing from the `package.cson` on sync.
 
 ### Commands
 

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -42,3 +42,8 @@ module.exports =
       description: 'Create package list when packages are installed or removed.'
       type: 'boolean'
       default: false
+    uninstall:
+      title: 'Uninstall packages on sync'
+      description: 'Uninstall packages not listed in packages.cson on sync.'
+      type: 'boolean'
+      default: false

--- a/spec/package-sync-spec.coffee
+++ b/spec/package-sync-spec.coffee
@@ -23,4 +23,11 @@ describe 'PackageSync', ->
       spyOn(atom, 'getConfigDirPath').andReturn(os.tmpdir())
       spyOn(atom.packages, 'getAvailablePackageNames').andReturn(['foo'])
 
-      expect(@sync.getMissingPackages()).toEqual(['bar', 'baz'])
+      expect(@sync.getMissingPackages(false)).toEqual(['bar', 'baz'])
+
+    it 'gets a list of installed packages, excluding ones that are in the list', ->
+      h.createPackages({'packages': ['foo', 'bar']})
+      spyOn(atom, 'getConfigDirPath').andReturn(os.tmpdir())
+      spyOn(atom.packages, 'getAvailablePackageNames').andReturn(['foo', 'bar', 'baz'])
+
+      expect(@sync.getMissingPackages(true)).toEqual(['baz'])


### PR DESCRIPTION
Adds a setting that, when enabled, uninstalls packages missing from `packages.cson` on sync. Fixes #11.
